### PR TITLE
Update to latest bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,4 +53,4 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.26.3"
+bindgen = "0.51.1"

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,8 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
+        // Generate rustified enums
+        .rustified_enum(".*")
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
Hi,

trying to build on raspberry, I encountered issues coming from a somewhat old version of bindgen, so I've updated to the latest one.

It cames with some enum generation changes. I've introduced an option to keep the old behaviour, which should be ok considering how enums are used by ta lib. 

Feel free to comment and thank you for your work ! : )